### PR TITLE
The ObjectModel nuget targets netstandard1.5 and not netstandard1.3

### DIFF
--- a/RFCs/0005-Test-Platform-SDK.md
+++ b/RFCs/0005-Test-Platform-SDK.md
@@ -31,7 +31,7 @@ Following is the `.NET` libraries supported by the ObjectModel package:
 | Version   | .NET runtime                      |
 |-----------|-----------------------------------|
 | 11.0.0    | net35, netstandard1.0             |
-| 15.0.0    | netstandard1.3                    |
+| 15.0.0    | netstandard1.5                    |
 
 [ObjectModelNuget]: http://www.nuget.org/packages/Microsoft.TestPlatform.ObjectModel/
 
@@ -59,7 +59,7 @@ Developers can use `Microsoft.TestPlatform.TranslationLayer` nuget package. It i
 
 | Version   | .NET runtime                      |
 |-----------|-----------------------------------|
-| 15.0.0    | netstandard1.3                    |
+| 15.0.0    | netstandard1.5                    |
 
 Protocol specification is available [here](0007-Editors-API-Specification.md).
 


### PR DESCRIPTION
… it targets netstandard1.5

![image](https://cloud.githubusercontent.com/assets/79742/23824439/ce0c7af2-066e-11e7-850c-f9bff06c352e.png)
