### PR TITLE
Updating to include a required individual component

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -14,8 +14,8 @@ Clone the repository to a local directory. Rest of this article assumes
 ```
 
 If you're planning to use **Visual Studio** as development environment, please
-install `VS 2017 RC 2` and the `.NET Core and Docker (Preview)` workload installed. See download
-link [here](https://www.microsoft.com/net/core#windowsvs2017).
+install `VS 2017 RC 2` or higher and the `.NET Core and Docker (Preview)` workload installed. See download
+link [here](https://www.microsoft.com/net/core#windowsvs2017). If you are using Visual Studio 2022 or higher, you would also need to install the inidividual component `.NET Portable Library targeting pack`.
 
 If you're _not_ planning to use **Visual Studio** and only use CLI. You will need to install [.Net 46 targeting pack](https://www.microsoft.com/en-us/download/details.aspx?id=48136). The download link has two msis. Both needs to be installed. Otherwise build will fail asking to install net 46.
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -14,8 +14,7 @@ Clone the repository to a local directory. Rest of this article assumes
 ```
 
 If you're planning to use **Visual Studio** as development environment, please
-install `VS 2017 RC 2` or higher and the `.NET Core and Docker (Preview)` workload installed. See download
-link [here](https://www.microsoft.com/net/core#windowsvs2017). If you are using Visual Studio 2022 or higher, you would also need to install the inidividual component `.NET Portable Library targeting pack`.
+install `VS 2022` with .NET Desktop development workload, and install individual component `.NET Portable Library targeting pack`.
 
 If you're _not_ planning to use **Visual Studio** and only use CLI. You will need to install [.Net 46 targeting pack](https://www.microsoft.com/en-us/download/details.aspx?id=48136). The download link has two msis. Both needs to be installed. Otherwise build will fail asking to install net 46.
 


### PR DESCRIPTION
I've kept this to a Visual Studio requirement, how do we pull this additional dependency down when someone is using the commandline?